### PR TITLE
Fix markdown list parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1075,10 +1075,10 @@
       // Bold
       text = text.replace(/\*\*(.*?)\*\*/gim, '<strong>$1</strong>');
 
-      // Simple lists
+      // Simple ordered lists
       text = text.replace(/^\d+\.\s+(.*)/gm, '<li>$1</li>');
       text = text.replace(/<\/li>\n<li>/g, '</li><li>');
-      text = text.replace(/<li>(.*?)<\/li>/gim, '<ol><li>$1</li></ol>');
+      text = text.replace(/(?:<li>.*?<\/li>)+/g, m => `<ol>${m}</ol>`);
 
       return text.trim();
     }


### PR DESCRIPTION
## Summary
- fix ordered list regex in `parseMarkdown`

## Testing
- `node - <<'NODE'
const text=`1. first\n2. second`;let html=text.replace(/^\d+\.\s+(.*)/gm,'<li>$1</li>');html=html.replace(/<\/li>\n<li>/g,'</li><li>');html=html.replace(/(?:<li>.*?<\/li>)+/g,m=>`<ol>${m}</ol>`);console.log(html)
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68405ddeb65483339cd4ce598933e0d2